### PR TITLE
Fixed root folder handling and added indexing support for custom folder structure

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -64,14 +64,25 @@ function parseTree(inputLines) {
   return root;
 }
 
-
 function indexStructure(structure) {
+  const keys = Object.keys(structure);
+  const total = keys.length;
+  let padLength = 0;
+  if (total > 99) {
+    padLength = 3;
+  } else if (total > 9) {
+    padLength = 2;
+  } else {
+    padLength = 1;
+  }
+
   let count = 1;
   const indexed = {};
 
-  for (const key of Object.keys(structure)) {
+  for (const key of keys) {
     const value = structure[key];
-    const newKey = `${count}. ${key}`;
+    const indexStr = String(count).padStart(padLength, "0");
+    const newKey = `${indexStr}. ${key}`;
     if (value && typeof value === "object") {
       indexed[newKey] = indexStructure(value);
     } else {

--- a/bin/index.js
+++ b/bin/index.js
@@ -64,6 +64,24 @@ function parseTree(inputLines) {
   return root;
 }
 
+
+function indexStructure(structure) {
+  let count = 1;
+  const indexed = {};
+
+  for (const key of Object.keys(structure)) {
+    const value = structure[key];
+    const newKey = `${count}. ${key}`;
+    if (value && typeof value === "object") {
+      indexed[newKey] = indexStructure(value);
+    } else {
+      indexed[newKey] = value;
+    }
+    count++;
+  }
+  return indexed;
+}
+
 // recursive function to create respective directories
 function createCustomWithContent(
   basePath,
@@ -106,6 +124,7 @@ program
   .option("--node", "Generate Node.js project")
   .option("--react", "Generate React project")
   .option("--custom", "Create project structure from pasted directory tree")
+  .option("--index", "Prefix folders/files with their order in the tree")
   .option("--verbose", "Enable verbose logging")
   .option("--debug", "Enable debug logs (more detailed)")
   //show version dynamically
@@ -288,7 +307,9 @@ program
       }
 
       const structure = parseTree(lines);
-      createCustomWithContent(targetDir, structure, verbose, debug);
+      const indexedStructure = indexStructure(structure);
+      const finalStructure = options.index ? indexedStructure : structure;
+      createCustomWithContent(targetDir, finalStructure, verbose, debug);
     } else {
       console.log(
         chalk.yellow(

--- a/bin/index.js
+++ b/bin/index.js
@@ -28,24 +28,17 @@ function isValidProjectName(name) {
 }
 
 function parseTree(inputLines) {
-  if (inputLines.length === 0) return {};
+  // The root is always the project folder, so we don't use the first line as root
+  const root = {}; // All pasted lines are children of the root
+  const stack = [{ depth: -1, node: root }];
 
-  // Parse the root folder name from the first line (e.g. "minion/")
-  const rootLine = inputLines[0].trim();
-  const rootName = rootLine.endsWith("/") ? rootLine.slice(0, -1) : rootLine;
-
-  const root = { [rootName]: {} }; // Root node with root folder key
-  const stack = [{ depth: -1, node: root[rootName] }]; // Start stack with root folder's object
-
-  // Helper to calculate depth based on position of branch characters
   function getDepth(line) {
     const branchIndex = line.search(/├── |└── /);
     if (branchIndex === -1) return 0;
-    return Math.floor(branchIndex / 4);
+    return Math.floor(branchIndex / 4) + 1; // +1 because root is depth 0
   }
 
-  // Start processing from second line (index 1), because index 0 is root
-  for (let i = 1; i < inputLines.length; i++) {
+  for (let i = 0; i < inputLines.length; i++) {
     const line = inputLines[i];
     if (!line.trim()) continue;
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -82,7 +82,7 @@ function indexStructure(structure) {
   for (const key of keys) {
     const value = structure[key];
     const indexStr = String(count).padStart(padLength, "0");
-    const newKey = `${indexStr}. ${key}`;
+    const newKey = `${indexStr} - ${key}`;
     if (value && typeof value === "object") {
       indexed[newKey] = indexStructure(value);
     } else {


### PR DESCRIPTION
1. Fix: Root folder behavior aligned with CLI command argument
Previously, skeldir assumed the first line of the folder skeleton as the root folder, resulting in an unintended double-root structure.
Example:

`skeldir project --custom`

```
folder1/
├── src/
│   └── main.js
├── test/
│   └── test.js
└── README.md
folder2/
├── src/
│   └── main.js
├── test/
│   └── test.js
└── README.md 
```

If the above folder tree was given as input, then output folder structure would be,

```
project/
└── folder1/
    ├── src/
    │   └── main.js
    ├── test/
    │   └── test.js
    ├── README.md
    └── folder2/
        ├── src/
        │   └── main.js
        ├── test/
        │   └── test.js
        └── README.md
```

rather than the expected output structure given below,

```
project/
├── folder1/
│   ├── src/
│   │   └── main.js
│   ├── test/
│   │   └── test.js
│   └── README.md
└── folder2/
    ├── src/
    │   └── main.js
    ├── test/
    │   └── test.js
    └── README.md
```

This PR removes the assumption of the first-line root and correctly uses the folder name provided in the CLI (project in this case) as the actual root, making the folder structure predictable and correct.

2. Feature: Optional indexing for folders to preserve order
An optional indexing feature is introduced for custom folder skeletons. This ensures that folders and files retain their intended order, as defined in the skeleton, even when viewed in systems that sort files alphabetically (e.g., GitHub).

Each folder or file is prefixed with an index (e.g., 1 - folder-name/ or 01 - folder-name/ for more than 10 subfolders or files and so on up to 999 subfolders and files) to maintain the original ordering. This helps in preserving structure especially for educational templates or tutorials.

for this input, 
`skeldir parent --custom --index`

```
sub1/
sub2/
sub3/
sub4/
sub5/
sub6/
sub7/
sub8/
sub9/
sub10/
sub11/
sub12/
```
we now get the output folder structure as,
```
parent/
├── 01 - sub1/
├── 02 - sub2/
├── 03 - sub3/
├── 04 - sub4/
├── 05 - sub5/
├── 06 - sub6/
├── 07 - sub7/
├── 08 - sub8/
├── 09 - sub9/
├── 10 - sub10/
├── 11 - sub11/
└── 12 - sub12/
```